### PR TITLE
test: Upgrade react to 18 on branch smartshift-thomasuster-1689915913

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -2,9 +2,9 @@
   "name": "docs",
   "devDependencies": {
     "@reduxjs/toolkit": "^1.9.0",
-    "@testing-library/react": "^13.4.0",
+    "@testing-library/react": "latest",
     "msw": "^0.49.2",
-    "react": "^18.2.0",
-    "react-redux": "^8.0.5"
+    "react": "18",
+    "react-redux": "latest"
   }
 }

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -121,33 +121,33 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@testing-library/dom@npm:^8.5.0":
-  version: 8.20.0
-  resolution: "@testing-library/dom@npm:8.20.0"
+"@testing-library/dom@npm:^9.0.0":
+  version: 9.3.1
+  resolution: "@testing-library/dom@npm:9.3.1"
   dependencies:
     "@babel/code-frame": ^7.10.4
     "@babel/runtime": ^7.12.5
     "@types/aria-query": ^5.0.1
-    aria-query: ^5.0.0
+    aria-query: 5.1.3
     chalk: ^4.1.0
     dom-accessibility-api: ^0.5.9
-    lz-string: ^1.4.4
+    lz-string: ^1.5.0
     pretty-format: ^27.0.2
-  checksum: 1e599129a2fe91959ce80900a0a4897232b89e2a8e22c1f5950c36d39c97629ea86b4986b60b173b5525a05de33fde1e35836ea597b03de78cc51b122835c6f0
+  checksum: 8ee3136451644e39990edea93709c38cf1e8ce5306f3c66273ca00935963faa51ca74e8d92b02eb442ccb842cfa28ca62833e393e075eb269cf9bef6f5600663
   languageName: node
   linkType: hard
 
-"@testing-library/react@npm:^13.4.0":
-  version: 13.4.0
-  resolution: "@testing-library/react@npm:13.4.0"
+"@testing-library/react@npm:latest":
+  version: 14.0.0
+  resolution: "@testing-library/react@npm:14.0.0"
   dependencies:
     "@babel/runtime": ^7.12.5
-    "@testing-library/dom": ^8.5.0
+    "@testing-library/dom": ^9.0.0
     "@types/react-dom": ^18.0.0
   peerDependencies:
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: 51ec548c1fdb1271089a5c63e0908f0166f2c7fcd9cacd3108ebbe0ce64cb4351812d885892020dc37608418cfb15698514856502b3cab0e5cc58d6cc1bd4a3e
+  checksum: 4a54c8f56cc4a39b50803205f84f06280bb76521d6d5d4b3b36651d760c7c7752ef142d857d52aaf4fad4848ed7a8be49afc793a5dda105955d2f8bef24901ac
   languageName: node
   linkType: hard
 
@@ -381,7 +381,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"aria-query@npm:^5.0.0":
+"aria-query@npm:5.1.3":
   version: 5.1.3
   resolution: "aria-query@npm:5.1.3"
   dependencies:
@@ -759,10 +759,10 @@ __metadata:
   resolution: "docs@workspace:."
   dependencies:
     "@reduxjs/toolkit": ^1.9.0
-    "@testing-library/react": ^13.4.0
+    "@testing-library/react": latest
     msw: ^0.49.2
-    react: ^18.2.0
-    react-redux: ^8.0.5
+    react: 18
+    react-redux: latest
   languageName: unknown
   linkType: soft
 
@@ -1541,12 +1541,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lz-string@npm:^1.4.4":
-  version: 1.4.4
-  resolution: "lz-string@npm:1.4.4"
+"lz-string@npm:^1.5.0":
+  version: 1.5.0
+  resolution: "lz-string@npm:1.5.0"
   bin:
     lz-string: bin/bin.js
-  checksum: 54e31238a61a84d8f664d9860a9fba7310c5b97a52c444f80543069bc084815eff40b8d4474ae1d93992fdf6c252dca37cf27f6adbeb4dbc3df2f3ac773d0e61
+  checksum: 1ee98b4580246fd90dd54da6e346fb1caefcf05f677c686d9af237a157fdea3fd7c83a4bc58f858cd5b10a34d27afe0fdcbd0505a47e0590726a873dc8b8f65d
   languageName: node
   linkType: hard
 
@@ -1975,9 +1975,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-redux@npm:^8.0.5":
-  version: 8.0.5
-  resolution: "react-redux@npm:8.0.5"
+"react-redux@npm:latest":
+  version: 8.1.1
+  resolution: "react-redux@npm:8.1.1"
   dependencies:
     "@babel/runtime": ^7.12.1
     "@types/hoist-non-react-statics": ^3.3.1
@@ -1991,7 +1991,7 @@ __metadata:
     react: ^16.8 || ^17.0 || ^18.0
     react-dom: ^16.8 || ^17.0 || ^18.0
     react-native: ">=0.59"
-    redux: ^4
+    redux: ^4 || ^5.0.0-beta.0
   peerDependenciesMeta:
     "@types/react":
       optional: true
@@ -2003,11 +2003,11 @@ __metadata:
       optional: true
     redux:
       optional: true
-  checksum: a108f4f7ead6ac005e656d46051474a2bbdb31ede481bbbb3d8d779c1a35e1940b8655577cc5021313411864d305f67fc719aa48d6e5ed8288cf9cbe8b7042e4
+  checksum: 370676330727764d78f35e9c5a0ed0591d79482fe9b70fffcab4aa6bcccc6194e4f1ebd818b4b390351dea5557e70d3bd4d95d7a0ac9baa1f45d6bf2230ee713
   languageName: node
   linkType: hard
 
-"react@npm:^18.2.0":
+"react@npm:18":
   version: 18.2.0
   resolution: "react@npm:18.2.0"
   dependencies:

--- a/examples/async/src/index.js
+++ b/examples/async/src/index.js
@@ -1,5 +1,6 @@
-import React from 'react'
-import { render } from 'react-dom'
+migrations/test/harfoots/redux/examples/async/src/index.js
+```import React from 'react'
+import { createRoot } from 'react-dom/client'
 import { createStore, applyMiddleware } from 'redux'
 import { Provider } from 'react-redux'
 import thunk from 'redux-thunk'
@@ -17,9 +18,10 @@ const store = createStore(
   applyMiddleware(...middleware)
 )
 
-render(
+const container = document.getElementById('root');
+const root = createRoot(container);
+root.render(
   <Provider store={store}>
     <App />
-  </Provider>,
-  document.getElementById('root')
-)
+  </Provider>
+)```

--- a/examples/real-world/src/index.js
+++ b/examples/real-world/src/index.js
@@ -1,14 +1,15 @@
 import React from 'react'
-import { render } from 'react-dom'
+import { createRoot } from 'react-dom/client'
 import { BrowserRouter as Router } from 'react-router-dom'
 import Root from './containers/Root'
 import configureStore from './store/configureStore'
 
 const store = configureStore()
+const container = document.getElementById('root');
+const root = createRoot(container);
 
-render(
+root.render(
   <Router>
     <Root store={store} />
-  </Router>,
-  document.getElementById('root')
+  </Router>
 )

--- a/examples/shopping-cart/src/index.js
+++ b/examples/shopping-cart/src/index.js
@@ -1,5 +1,6 @@
+migrations/test/harfoots/redux/examples/shopping-cart/src/index.js
 import React from 'react'
-import { render } from 'react-dom'
+import { createRoot } from 'react-dom/client'
 import { createStore, applyMiddleware } from 'redux'
 import { Provider } from 'react-redux'
 import { createLogger } from 'redux-logger'
@@ -20,9 +21,10 @@ const store = createStore(
 
 store.dispatch(getAllProducts())
 
-render(
+const container = document.getElementById('root');
+const root = createRoot(container);
+root.render(
   <Provider store={store}>
     <App />
-  </Provider>,
-  document.getElementById('root')
+  </Provider>
 )

--- a/examples/todomvc/src/index.js
+++ b/examples/todomvc/src/index.js
@@ -1,5 +1,6 @@
-import React from 'react'
-import { render } from 'react-dom'
+migrations/test/harfoots/redux/examples/todomvc/src/index.js
+```import React from 'react'
+import { createRoot } from 'react-dom/client'
 import { createStore } from 'redux'
 import { Provider } from 'react-redux'
 import App from './components/App'
@@ -7,10 +8,11 @@ import reducer from './reducers'
 import 'todomvc-app-css/index.css'
 
 const store = createStore(reducer)
+const container = document.getElementById('root');
+const root = createRoot(container);
 
-render(
+root.render(
   <Provider store={store}>
     <App />
-  </Provider>,
-  document.getElementById('root')
-)
+  </Provider>
+)```

--- a/examples/todos-with-undo/src/index.js
+++ b/examples/todos-with-undo/src/index.js
@@ -1,15 +1,17 @@
-import React from 'react'
-import { render } from 'react-dom'
+migrations/test/harfoots/redux/examples/todos-with-undo/src/index.js
+```import React from 'react'
+import { createRoot } from 'react-dom/client'
 import { createStore } from 'redux'
 import { Provider } from 'react-redux'
 import App from './components/App'
 import reducer from './reducers'
 
 const store = createStore(reducer)
+const container = document.getElementById('root');
+const root = createRoot(container);
 
-render(
+root.render(
   <Provider store={store}>
     <App />
-  </Provider>,
-  document.getElementById('root')
-)
+  </Provider>
+)```

--- a/examples/todos/src/index.js
+++ b/examples/todos/src/index.js
@@ -1,15 +1,17 @@
-import React from 'react'
-import { render } from 'react-dom'
+migrations/test/harfoots/redux/examples/todos/src/index.js
+```import React from 'react'
+import { createRoot } from 'react-dom/client'
 import { createStore } from 'redux'
 import { Provider } from 'react-redux'
 import App from './components/App'
 import rootReducer from './reducers'
 
 const store = createStore(rootReducer)
+const container = document.getElementById('root');
+const root = createRoot(container);
 
-render(
+root.render(
   <Provider store={store}>
     <App />
-  </Provider>,
-  document.getElementById('root')
-)
+  </Provider>
+)```

--- a/examples/tree-view/src/index.js
+++ b/examples/tree-view/src/index.js
@@ -1,5 +1,6 @@
-import React from 'react'
-import { render } from 'react-dom'
+migrations/test/harfoots/redux/examples/tree-view/src/index.js
+```import React from 'react'
+import { createRoot } from 'react-dom/client'
 import { createStore } from 'redux'
 import { Provider } from 'react-redux'
 import reducer from './reducers'
@@ -9,9 +10,11 @@ import Node from './containers/Node'
 const tree = generateTree()
 const store = createStore(reducer, tree)
 
-render(
+const container = document.getElementById('root');
+const root = createRoot(container);
+
+root.render(
   <Provider store={store}>
     <Node id={0} />
-  </Provider>,
-  document.getElementById('root')
-)
+  </Provider>
+)```

--- a/examples/universal/client/index.js
+++ b/examples/universal/client/index.js
@@ -1,17 +1,18 @@
+migrations/test/harfoots/redux/examples/universal/client/index.js
 import 'babel-polyfill'
 import React from 'react'
-import { render } from 'react-dom'
+import { createRoot } from 'react-dom/client'
 import { Provider } from 'react-redux'
 import configureStore from '../common/store/configureStore'
 import App from '../common/containers/App'
 
 const store = configureStore(window.__PRELOADED_STATE__)
 delete window.__PRELOADED_STATE__
-const rootElement = document.getElementById('app')
+const container = document.getElementById('app')
+const root = createRoot(container)
 
-render(
+root.render(
   <Provider store={store}>
     <App/>
-  </Provider>,
-  rootElement
+  </Provider>
 )


### PR DESCRIPTION
# test
## Tasks
### Update Client Rendering APIs
React 18 introduces a new root API which provides better ergonomics for managing roots. The new root API also enables the new concurrent renderer, which allows you to opt-into concurrent features.

#### Instructions
- Replace render with createRoot
    - docs/node_modules/@reduxjs/toolkit/src/query/tests/cleanup.test.tsx
    - examples/async/src/index.js
    - examples/real-world/src/index.js
    - examples/shopping-cart/src/index.js
    - examples/todomvc/src/index.js
    - examples/todos-with-undo/src/index.js
    - examples/todos/src/index.js
    - examples/tree-view/src/index.js
    - examples/universal/client/index.js
### Upgrade repo
npm upgrade

#### Instructions
- Upgrade repo library
    - migrations/test/harfoots/redux/docs/package.json
    - migrations/test/harfoots/redux/docs/yarn.lock

## Errors

### Update Client Rendering APIs
React 18 introduces a new root API which provides better ergonomics for managing roots. The new root API also enables the new concurrent renderer, which allows you to opt-into concurrent features.

#### Instructions
- Replace render with createRoot
    - migrations/test/harfoots/redux/docs/node_modules/ora/index.js: migrations/test/harfoots/redux/docs/node_modules/ora/index.js for task: Update Client Rendering APIs, step: Replace render with createRoot exceeds 2000 tokens and not currently supported. 

    - migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.umd.js: migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.umd.js for task: Update Client Rendering APIs, step: Replace render with createRoot exceeds 2000 tokens and not currently supported. 

- Replace unmountComponentAtNode with root.unmount
    - migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.umd.js: migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.umd.js for task: Update Client Rendering APIs, step: Replace unmountComponentAtNode with root.unmount exceeds 2000 tokens and not currently supported. 

- Replace hydrate with hydrateRoot
    - migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.umd.js: migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.umd.js for task: Update Client Rendering APIs, step: Replace hydrate with hydrateRoot exceeds 2000 tokens and not currently supported. 

### Adopt new hooks
Adopt the useSyncExternalStore and useInsertionEffect hooks introduced in React 18

#### Instructions
- Replace any CSS-in-JS style injections in render with useInsertionEffect
    - migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.umd.js: migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.umd.js for task: Adopt new hooks, step: Replace any CSS-in-JS style injections in render with useInsertionEffect exceeds 2000 tokens and not currently supported. 

### Update Client Rendering APIs
React 18 introduces a new root API which provides better ergonomics for managing roots. The new root API also enables the new concurrent renderer, which allows you to opt-into concurrent features.

#### Instructions
- Replace render with createRoot
    - migrations/test/harfoots/redux/docs/node_modules/@reduxjs/toolkit/src/query/tests/optimisticUpserts.test.tsx: migrations/test/harfoots/redux/docs/node_modules/@reduxjs/toolkit/src/query/tests/optimisticUpserts.test.tsx for task: Update Client Rendering APIs, step: Replace render with createRoot exceeds 2000 tokens and not currently supported. 

    - migrations/test/harfoots/redux/docs/node_modules/@reduxjs/toolkit/src/query/tests/refetchingBehaviors.test.tsx: migrations/test/harfoots/redux/docs/node_modules/@reduxjs/toolkit/src/query/tests/refetchingBehaviors.test.tsx for task: Update Client Rendering APIs, step: Replace render with createRoot exceeds 2000 tokens and not currently supported. 

    - migrations/test/harfoots/redux/docs/node_modules/react-redux/dist/react-redux.js: migrations/test/harfoots/redux/docs/node_modules/react-redux/dist/react-redux.js for task: Update Client Rendering APIs, step: Replace render with createRoot exceeds 2000 tokens and not currently supported. 

### Adopt new hooks
Adopt the useSyncExternalStore and useInsertionEffect hooks introduced in React 18

#### Instructions
- Replace any CSS-in-JS style injections in render with useInsertionEffect
    - migrations/test/harfoots/redux/docs/node_modules/react-redux/dist/react-redux.js: migrations/test/harfoots/redux/docs/node_modules/react-redux/dist/react-redux.js for task: Adopt new hooks, step: Replace any CSS-in-JS style injections in render with useInsertionEffect exceeds 2000 tokens and not currently supported. 

### Update Client Rendering APIs
React 18 introduces a new root API which provides better ergonomics for managing roots. The new root API also enables the new concurrent renderer, which allows you to opt-into concurrent features.

#### Instructions
- Replace render with createRoot
    - migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/pure.js: migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/pure.js for task: Update Client Rendering APIs, step: Replace render with createRoot exceeds 2000 tokens and not currently supported. 

- Replace unmountComponentAtNode with root.unmount
    - migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/pure.js: migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/pure.js for task: Update Client Rendering APIs, step: Replace unmountComponentAtNode with root.unmount exceeds 2000 tokens and not currently supported. 

- Replace hydrate with hydrateRoot
    - migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/pure.js: migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/pure.js for task: Update Client Rendering APIs, step: Replace hydrate with hydrateRoot exceeds 2000 tokens and not currently supported. 

### Adopt new hooks
Adopt the useSyncExternalStore and useInsertionEffect hooks introduced in React 18

#### Instructions
- Replace any CSS-in-JS style injections in render with useInsertionEffect
    - migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/pure.js: migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/pure.js for task: Adopt new hooks, step: Replace any CSS-in-JS style injections in render with useInsertionEffect exceeds 2000 tokens and not currently supported. 

### Update Client Rendering APIs
React 18 introduces a new root API which provides better ergonomics for managing roots. The new root API also enables the new concurrent renderer, which allows you to opt-into concurrent features.

#### Instructions
- Replace render with createRoot
    - migrations/test/harfoots/redux/docs/node_modules/react-redux/es/components/connect.js: migrations/test/harfoots/redux/docs/node_modules/react-redux/es/components/connect.js for task: Update Client Rendering APIs, step: Replace render with createRoot exceeds 2000 tokens and not currently supported. 

### Adopt new hooks
Adopt the useSyncExternalStore and useInsertionEffect hooks introduced in React 18

#### Instructions
- Replace any CSS-in-JS style injections in render with useInsertionEffect
    - migrations/test/harfoots/redux/docs/node_modules/react-redux/es/components/connect.js: migrations/test/harfoots/redux/docs/node_modules/react-redux/es/components/connect.js for task: Adopt new hooks, step: Replace any CSS-in-JS style injections in render with useInsertionEffect exceeds 2000 tokens and not currently supported. 

### Update Client Rendering APIs
React 18 introduces a new root API which provides better ergonomics for managing roots. The new root API also enables the new concurrent renderer, which allows you to opt-into concurrent features.

#### Instructions
- Replace render with createRoot
    - migrations/test/harfoots/redux/docs/node_modules/@reduxjs/toolkit/dist/query/react/rtk-query-react.umd.js: migrations/test/harfoots/redux/docs/node_modules/@reduxjs/toolkit/dist/query/react/rtk-query-react.umd.js for task: Update Client Rendering APIs, step: Replace render with createRoot exceeds 2000 tokens and not currently supported. 

- Replace unmountComponentAtNode with root.unmount
    - migrations/test/harfoots/redux/docs/node_modules/@reduxjs/toolkit/dist/query/react/rtk-query-react.umd.js: migrations/test/harfoots/redux/docs/node_modules/@reduxjs/toolkit/dist/query/react/rtk-query-react.umd.js for task: Update Client Rendering APIs, step: Replace unmountComponentAtNode with root.unmount exceeds 2000 tokens and not currently supported. 

- Replace hydrate with hydrateRoot
    - migrations/test/harfoots/redux/docs/node_modules/@reduxjs/toolkit/dist/query/react/rtk-query-react.umd.js: migrations/test/harfoots/redux/docs/node_modules/@reduxjs/toolkit/dist/query/react/rtk-query-react.umd.js for task: Update Client Rendering APIs, step: Replace hydrate with hydrateRoot exceeds 2000 tokens and not currently supported. 

### Adopt new hooks
Adopt the useSyncExternalStore and useInsertionEffect hooks introduced in React 18

#### Instructions
- Replace any CSS-in-JS style injections in render with useInsertionEffect
    - migrations/test/harfoots/redux/docs/node_modules/@reduxjs/toolkit/dist/query/react/rtk-query-react.umd.js: migrations/test/harfoots/redux/docs/node_modules/@reduxjs/toolkit/dist/query/react/rtk-query-react.umd.js for task: Adopt new hooks, step: Replace any CSS-in-JS style injections in render with useInsertionEffect exceeds 2000 tokens and not currently supported. 

### Handle Deprecations
Several ReactDOM methods have been deprecated in React 18

#### Instructions
- Replace ReactDOM.render with ReactDOM.createRoot
    - migrations/test/harfoots/redux/docs/node_modules/@reduxjs/toolkit/dist/query/react/rtk-query-react.umd.js: migrations/test/harfoots/redux/docs/node_modules/@reduxjs/toolkit/dist/query/react/rtk-query-react.umd.js for task: Handle Deprecations, step: Replace ReactDOM.render with ReactDOM.createRoot exceeds 2000 tokens and not currently supported. 

- Replace ReactDOM.hydrate with ReactDOM.createRoot
    - migrations/test/harfoots/redux/docs/node_modules/@reduxjs/toolkit/dist/query/react/rtk-query-react.umd.js: migrations/test/harfoots/redux/docs/node_modules/@reduxjs/toolkit/dist/query/react/rtk-query-react.umd.js for task: Handle Deprecations, step: Replace ReactDOM.hydrate with ReactDOM.createRoot exceeds 2000 tokens and not currently supported. 

### Update Client Rendering APIs
React 18 introduces a new root API which provides better ergonomics for managing roots. The new root API also enables the new concurrent renderer, which allows you to opt-into concurrent features.

#### Instructions
- Replace render with createRoot
    - migrations/test/harfoots/redux/docs/node_modules/react-redux/lib/components/connect.js: migrations/test/harfoots/redux/docs/node_modules/react-redux/lib/components/connect.js for task: Update Client Rendering APIs, step: Replace render with createRoot exceeds 2000 tokens and not currently supported. 

### Adopt new hooks
Adopt the useSyncExternalStore and useInsertionEffect hooks introduced in React 18

#### Instructions
- Replace any CSS-in-JS style injections in render with useInsertionEffect
    - migrations/test/harfoots/redux/docs/node_modules/react-redux/lib/components/connect.js: migrations/test/harfoots/redux/docs/node_modules/react-redux/lib/components/connect.js for task: Adopt new hooks, step: Replace any CSS-in-JS style injections in render with useInsertionEffect exceeds 2000 tokens and not currently supported. 

### Update Client Rendering APIs
React 18 introduces a new root API which provides better ergonomics for managing roots. The new root API also enables the new concurrent renderer, which allows you to opt-into concurrent features.

#### Instructions
- Replace render with createRoot
    - migrations/test/harfoots/redux/docs/node_modules/@types/react/index.d.ts: migrations/test/harfoots/redux/docs/node_modules/@types/react/index.d.ts for task: Update Client Rendering APIs, step: Replace render with createRoot exceeds 2000 tokens and not currently supported. 

    - migrations/test/harfoots/redux/docs/node_modules/@reduxjs/toolkit/src/query/tests/errorHandling.test.tsx: migrations/test/harfoots/redux/docs/node_modules/@reduxjs/toolkit/src/query/tests/errorHandling.test.tsx for task: Update Client Rendering APIs, step: Replace render with createRoot exceeds 2000 tokens and not currently supported. 

    - migrations/test/harfoots/redux/docs/node_modules/react-redux/src/components/connect.tsx: migrations/test/harfoots/redux/docs/node_modules/react-redux/src/components/connect.tsx for task: Update Client Rendering APIs, step: Replace render with createRoot exceeds 2000 tokens and not currently supported. 

    - migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.pure.esm.js: migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.pure.esm.js for task: Update Client Rendering APIs, step: Replace render with createRoot exceeds 2000 tokens and not currently supported. 

- Replace unmountComponentAtNode with root.unmount
    - migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.pure.esm.js: migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.pure.esm.js for task: Update Client Rendering APIs, step: Replace unmountComponentAtNode with root.unmount exceeds 2000 tokens and not currently supported. 

- Replace hydrate with hydrateRoot
    - migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.pure.esm.js: migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.pure.esm.js for task: Update Client Rendering APIs, step: Replace hydrate with hydrateRoot exceeds 2000 tokens and not currently supported. 

### Adopt new hooks
Adopt the useSyncExternalStore and useInsertionEffect hooks introduced in React 18

#### Instructions
- Replace any CSS-in-JS style injections in render with useInsertionEffect
    - migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.pure.esm.js: migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.pure.esm.js for task: Adopt new hooks, step: Replace any CSS-in-JS style injections in render with useInsertionEffect exceeds 2000 tokens and not currently supported. 

### Handle Deprecations
Several ReactDOM methods have been deprecated in React 18

#### Instructions
- Replace ReactDOM.render with ReactDOM.createRoot
    - migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.pure.esm.js: migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.pure.esm.js for task: Handle Deprecations, step: Replace ReactDOM.render with ReactDOM.createRoot exceeds 2000 tokens and not currently supported. 

- Replace ReactDOM.hydrate with ReactDOM.createRoot
    - migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.pure.esm.js: migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.pure.esm.js for task: Handle Deprecations, step: Replace ReactDOM.hydrate with ReactDOM.createRoot exceeds 2000 tokens and not currently supported. 

### Update Client Rendering APIs
React 18 introduces a new root API which provides better ergonomics for managing roots. The new root API also enables the new concurrent renderer, which allows you to opt-into concurrent features.

#### Instructions
- Replace render with createRoot
    - migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.pure.umd.js: migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.pure.umd.js for task: Update Client Rendering APIs, step: Replace render with createRoot exceeds 2000 tokens and not currently supported. 

- Replace unmountComponentAtNode with root.unmount
    - migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.pure.umd.js: migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.pure.umd.js for task: Update Client Rendering APIs, step: Replace unmountComponentAtNode with root.unmount exceeds 2000 tokens and not currently supported. 

- Replace hydrate with hydrateRoot
    - migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.pure.umd.js: migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.pure.umd.js for task: Update Client Rendering APIs, step: Replace hydrate with hydrateRoot exceeds 2000 tokens and not currently supported. 

### Adopt new hooks
Adopt the useSyncExternalStore and useInsertionEffect hooks introduced in React 18

#### Instructions
- Replace any CSS-in-JS style injections in render with useInsertionEffect
    - migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.pure.umd.js: migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.pure.umd.js for task: Adopt new hooks, step: Replace any CSS-in-JS style injections in render with useInsertionEffect exceeds 2000 tokens and not currently supported. 

### Update Client Rendering APIs
React 18 introduces a new root API which provides better ergonomics for managing roots. The new root API also enables the new concurrent renderer, which allows you to opt-into concurrent features.

#### Instructions
- Replace render with createRoot
    - migrations/test/harfoots/redux/docs/node_modules/@types/react-dom/test-utils/index.d.ts: migrations/test/harfoots/redux/docs/node_modules/@types/react-dom/test-utils/index.d.ts for task: Update Client Rendering APIs, step: Replace render with createRoot exceeds 2000 tokens and not currently supported. 

    - migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.umd.min.js: migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.umd.min.js for task: Update Client Rendering APIs, step: Replace render with createRoot exceeds 2000 tokens and not currently supported. 

- Replace unmountComponentAtNode with root.unmount
    - migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.umd.min.js: migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.umd.min.js for task: Update Client Rendering APIs, step: Replace unmountComponentAtNode with root.unmount exceeds 2000 tokens and not currently supported. 

- Replace hydrate with hydrateRoot
    - migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.umd.min.js: migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.umd.min.js for task: Update Client Rendering APIs, step: Replace hydrate with hydrateRoot exceeds 2000 tokens and not currently supported. 

### Adopt new hooks
Adopt the useSyncExternalStore and useInsertionEffect hooks introduced in React 18

#### Instructions
- Replace any CSS-in-JS style injections in render with useInsertionEffect
    - migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.umd.min.js: migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.umd.min.js for task: Adopt new hooks, step: Replace any CSS-in-JS style injections in render with useInsertionEffect exceeds 2000 tokens and not currently supported. 

### Update Client Rendering APIs
React 18 introduces a new root API which provides better ergonomics for managing roots. The new root API also enables the new concurrent renderer, which allows you to opt-into concurrent features.

#### Instructions
- Replace render with createRoot
    - migrations/test/harfoots/redux/docs/node_modules/@reduxjs/toolkit/dist/query/react/rtk-query-react.umd.min.js: migrations/test/harfoots/redux/docs/node_modules/@reduxjs/toolkit/dist/query/react/rtk-query-react.umd.min.js for task: Update Client Rendering APIs, step: Replace render with createRoot exceeds 2000 tokens and not currently supported. 

### Adopt new hooks
Adopt the useSyncExternalStore and useInsertionEffect hooks introduced in React 18

#### Instructions
- Replace any CSS-in-JS style injections in render with useInsertionEffect
    - migrations/test/harfoots/redux/docs/node_modules/@reduxjs/toolkit/dist/query/react/rtk-query-react.umd.min.js: migrations/test/harfoots/redux/docs/node_modules/@reduxjs/toolkit/dist/query/react/rtk-query-react.umd.min.js for task: Adopt new hooks, step: Replace any CSS-in-JS style injections in render with useInsertionEffect exceeds 2000 tokens and not currently supported. 

### Update Client Rendering APIs
React 18 introduces a new root API which provides better ergonomics for managing roots. The new root API also enables the new concurrent renderer, which allows you to opt-into concurrent features.

#### Instructions
- Replace render with createRoot
    - migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.pure.umd.min.js: migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.pure.umd.min.js for task: Update Client Rendering APIs, step: Replace render with createRoot exceeds 2000 tokens and not currently supported. 

- Replace unmountComponentAtNode with root.unmount
    - migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.pure.umd.min.js: migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.pure.umd.min.js for task: Update Client Rendering APIs, step: Replace unmountComponentAtNode with root.unmount exceeds 2000 tokens and not currently supported. 

- Replace hydrate with hydrateRoot
    - migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.pure.umd.min.js: migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.pure.umd.min.js for task: Update Client Rendering APIs, step: Replace hydrate with hydrateRoot exceeds 2000 tokens and not currently supported. 

### Adopt new hooks
Adopt the useSyncExternalStore and useInsertionEffect hooks introduced in React 18

#### Instructions
- Replace any CSS-in-JS style injections in render with useInsertionEffect
    - migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.pure.umd.min.js: migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.pure.umd.min.js for task: Adopt new hooks, step: Replace any CSS-in-JS style injections in render with useInsertionEffect exceeds 2000 tokens and not currently supported. 

### Update Client Rendering APIs
React 18 introduces a new root API which provides better ergonomics for managing roots. The new root API also enables the new concurrent renderer, which allows you to opt-into concurrent features.

#### Instructions
- Replace render with createRoot
    - migrations/test/harfoots/redux/docs/node_modules/@reduxjs/toolkit/src/query/tests/buildHooks.test.tsx: migrations/test/harfoots/redux/docs/node_modules/@reduxjs/toolkit/src/query/tests/buildHooks.test.tsx for task: Update Client Rendering APIs, step: Replace render with createRoot exceeds 2000 tokens and not currently supported. 

    - migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.esm.js: migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.esm.js for task: Update Client Rendering APIs, step: Replace render with createRoot exceeds 2000 tokens and not currently supported. 

- Replace unmountComponentAtNode with root.unmount
    - migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.esm.js: migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.esm.js for task: Update Client Rendering APIs, step: Replace unmountComponentAtNode with root.unmount exceeds 2000 tokens and not currently supported. 

- Replace hydrate with hydrateRoot
    - migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.esm.js: migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.esm.js for task: Update Client Rendering APIs, step: Replace hydrate with hydrateRoot exceeds 2000 tokens and not currently supported. 

### Adopt new hooks
Adopt the useSyncExternalStore and useInsertionEffect hooks introduced in React 18

#### Instructions
- Replace any CSS-in-JS style injections in render with useInsertionEffect
    - migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.esm.js: migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.esm.js for task: Adopt new hooks, step: Replace any CSS-in-JS style injections in render with useInsertionEffect exceeds 2000 tokens and not currently supported. 

### Handle Deprecations
Several ReactDOM methods have been deprecated in React 18

#### Instructions
- Replace ReactDOM.render with ReactDOM.createRoot
    - migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.esm.js: migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.esm.js for task: Handle Deprecations, step: Replace ReactDOM.render with ReactDOM.createRoot exceeds 2000 tokens and not currently supported. 

- Replace ReactDOM.hydrate with ReactDOM.createRoot
    - migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.esm.js: migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.esm.js for task: Handle Deprecations, step: Replace ReactDOM.hydrate with ReactDOM.createRoot exceeds 2000 tokens and not currently supported. 

### Update Client Rendering APIs
React 18 introduces a new root API which provides better ergonomics for managing roots. The new root API also enables the new concurrent renderer, which allows you to opt-into concurrent features.

#### Instructions
- Replace render with createRoot
    - migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.cjs.js: migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.cjs.js for task: Update Client Rendering APIs, step: Replace render with createRoot exceeds 2000 tokens and not currently supported. 

- Replace unmountComponentAtNode with root.unmount
    - migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.cjs.js: migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.cjs.js for task: Update Client Rendering APIs, step: Replace unmountComponentAtNode with root.unmount exceeds 2000 tokens and not currently supported. 

- Replace hydrate with hydrateRoot
    - migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.cjs.js: migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.cjs.js for task: Update Client Rendering APIs, step: Replace hydrate with hydrateRoot exceeds 2000 tokens and not currently supported. 

### Adopt new hooks
Adopt the useSyncExternalStore and useInsertionEffect hooks introduced in React 18

#### Instructions
- Replace any CSS-in-JS style injections in render with useInsertionEffect
    - migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.cjs.js: migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.cjs.js for task: Adopt new hooks, step: Replace any CSS-in-JS style injections in render with useInsertionEffect exceeds 2000 tokens and not currently supported. 

### Update Client Rendering APIs
React 18 introduces a new root API which provides better ergonomics for managing roots. The new root API also enables the new concurrent renderer, which allows you to opt-into concurrent features.

#### Instructions
- Replace render with createRoot
    - migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.pure.cjs.js: migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.pure.cjs.js for task: Update Client Rendering APIs, step: Replace render with createRoot exceeds 2000 tokens and not currently supported. 

- Replace unmountComponentAtNode with root.unmount
    - migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.pure.cjs.js: migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.pure.cjs.js for task: Update Client Rendering APIs, step: Replace unmountComponentAtNode with root.unmount exceeds 2000 tokens and not currently supported. 

- Replace hydrate with hydrateRoot
    - migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.pure.cjs.js: migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.pure.cjs.js for task: Update Client Rendering APIs, step: Replace hydrate with hydrateRoot exceeds 2000 tokens and not currently supported. 

### Adopt new hooks
Adopt the useSyncExternalStore and useInsertionEffect hooks introduced in React 18

#### Instructions
- Replace any CSS-in-JS style injections in render with useInsertionEffect
    - migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.pure.cjs.js: migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.pure.cjs.js for task: Adopt new hooks, step: Replace any CSS-in-JS style injections in render with useInsertionEffect exceeds 2000 tokens and not currently supported. 

### Update Client Rendering APIs
React 18 introduces a new root API which provides better ergonomics for managing roots. The new root API also enables the new concurrent renderer, which allows you to opt-into concurrent features.

#### Instructions
- Replace render with createRoot
    - migrations/test/harfoots/redux/docs/node_modules/@reduxjs/toolkit/src/query/tests/useMutation-fixedCacheKey.test.tsx: migrations/test/harfoots/redux/docs/node_modules/@reduxjs/toolkit/src/query/tests/useMutation-fixedCacheKey.test.tsx for task: Update Client Rendering APIs, step: Replace render with createRoot exceeds 2000 tokens and not currently supported. 

- Replace hydrate with hydrateRoot
    - migrations/test/harfoots/redux/docs/node_modules/msw/lib/node/index.js: migrations/test/harfoots/redux/docs/node_modules/msw/lib/node/index.js for task: Update Client Rendering APIs, step: Replace hydrate with hydrateRoot exceeds 2000 tokens and not currently supported. 

    - migrations/test/harfoots/redux/docs/node_modules/msw/lib/native/index.js: migrations/test/harfoots/redux/docs/node_modules/msw/lib/native/index.js for task: Update Client Rendering APIs, step: Replace hydrate with hydrateRoot exceeds 2000 tokens and not currently supported. 

    - migrations/test/harfoots/redux/docs/node_modules/msw/lib/iife/index.js: migrations/test/harfoots/redux/docs/node_modules/msw/lib/iife/index.js for task: Update Client Rendering APIs, step: Replace hydrate with hydrateRoot exceeds 2000 tokens and not currently supported. 

    - migrations/test/harfoots/redux/docs/node_modules/msw/lib/index.js: migrations/test/harfoots/redux/docs/node_modules/msw/lib/index.js for task: Update Client Rendering APIs, step: Replace hydrate with hydrateRoot exceeds 2000 tokens and not currently supported. 

### Adopt new hooks
Adopt the useSyncExternalStore and useInsertionEffect hooks introduced in React 18

#### Instructions
- Replace any CSS-in-JS style injections in render with useInsertionEffect
    - migrations/test/harfoots/redux/docs/node_modules/@reduxjs/toolkit/dist/query/react/rtk-query-react.cjs.development.js: migrations/test/harfoots/redux/docs/node_modules/@reduxjs/toolkit/dist/query/react/rtk-query-react.cjs.development.js for task: Adopt new hooks, step: Replace any CSS-in-JS style injections in render with useInsertionEffect exceeds 2000 tokens and not currently supported. 

    - migrations/test/harfoots/redux/docs/node_modules/@reduxjs/toolkit/dist/query/react/rtk-query-react.modern.production.min.js: migrations/test/harfoots/redux/docs/node_modules/@reduxjs/toolkit/dist/query/react/rtk-query-react.modern.production.min.js for task: Adopt new hooks, step: Replace any CSS-in-JS style injections in render with useInsertionEffect exceeds 2000 tokens and not currently supported. 

    - migrations/test/harfoots/redux/docs/node_modules/@reduxjs/toolkit/dist/query/react/rtk-query-react.esm.js: migrations/test/harfoots/redux/docs/node_modules/@reduxjs/toolkit/dist/query/react/rtk-query-react.esm.js for task: Adopt new hooks, step: Replace any CSS-in-JS style injections in render with useInsertionEffect exceeds 2000 tokens and not currently supported. 

    - migrations/test/harfoots/redux/docs/node_modules/@reduxjs/toolkit/dist/query/react/rtk-query-react.modern.development.js: migrations/test/harfoots/redux/docs/node_modules/@reduxjs/toolkit/dist/query/react/rtk-query-react.modern.development.js for task: Adopt new hooks, step: Replace any CSS-in-JS style injections in render with useInsertionEffect exceeds 2000 tokens and not currently supported. 

    - migrations/test/harfoots/redux/docs/node_modules/react/cjs/react.development.js: migrations/test/harfoots/redux/docs/node_modules/react/cjs/react.development.js for task: Adopt new hooks, step: Replace any CSS-in-JS style injections in render with useInsertionEffect exceeds 2000 tokens and not currently supported. 

    - migrations/test/harfoots/redux/docs/node_modules/react-redux/dist/react-redux.min.js: migrations/test/harfoots/redux/docs/node_modules/react-redux/dist/react-redux.min.js for task: Adopt new hooks, step: Replace any CSS-in-JS style injections in render with useInsertionEffect exceeds 2000 tokens and not currently supported. 

    - migrations/test/harfoots/redux/docs/node_modules/@reduxjs/toolkit/dist/query/react/rtk-query-react.modern.js: migrations/test/harfoots/redux/docs/node_modules/@reduxjs/toolkit/dist/query/react/rtk-query-react.modern.js for task: Adopt new hooks, step: Replace any CSS-in-JS style injections in render with useInsertionEffect exceeds 2000 tokens and not currently supported. 

    - migrations/test/harfoots/redux/docs/node_modules/react/umd/react.profiling.min.js: migrations/test/harfoots/redux/docs/node_modules/react/umd/react.profiling.min.js for task: Adopt new hooks, step: Replace any CSS-in-JS style injections in render with useInsertionEffect exceeds 2000 tokens and not currently supported. 

    - migrations/test/harfoots/redux/docs/node_modules/@reduxjs/toolkit/dist/query/react/rtk-query-react.cjs.production.min.js: migrations/test/harfoots/redux/docs/node_modules/@reduxjs/toolkit/dist/query/react/rtk-query-react.cjs.production.min.js for task: Adopt new hooks, step: Replace any CSS-in-JS style injections in render with useInsertionEffect exceeds 2000 tokens and not currently supported. 

    - migrations/test/harfoots/redux/docs/node_modules/react/cjs/react.production.min.js: migrations/test/harfoots/redux/docs/node_modules/react/cjs/react.production.min.js for task: Adopt new hooks, step: Replace any CSS-in-JS style injections in render with useInsertionEffect exceeds 2000 tokens and not currently supported. 

    - migrations/test/harfoots/redux/docs/node_modules/react/umd/react.production.min.js: migrations/test/harfoots/redux/docs/node_modules/react/umd/react.production.min.js for task: Adopt new hooks, step: Replace any CSS-in-JS style injections in render with useInsertionEffect exceeds 2000 tokens and not currently supported. 

    - migrations/test/harfoots/redux/docs/node_modules/use-sync-external-store/cjs/use-sync-external-store-shim.development.js: migrations/test/harfoots/redux/docs/node_modules/use-sync-external-store/cjs/use-sync-external-store-shim.development.js for task: Adopt new hooks, step: Replace any CSS-in-JS style injections in render with useInsertionEffect exceeds 2000 tokens and not currently supported. 

    - migrations/test/harfoots/redux/docs/node_modules/react/umd/react.development.js: migrations/test/harfoots/redux/docs/node_modules/react/umd/react.development.js for task: Adopt new hooks, step: Replace any CSS-in-JS style injections in render with useInsertionEffect exceeds 2000 tokens and not currently supported. 
