### PR TITLE
test: Upgrade react to 18 on branch smartshift-thomasuster-1690309838

### DIFF
--- a/examples/async/src/index.js
+++ b/examples/async/src/index.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render } from 'react-dom'
+import { createRoot } from 'react-dom/client'
 import { createStore, applyMiddleware } from 'redux'
 import { Provider } from 'react-redux'
 import thunk from 'redux-thunk'
@@ -17,9 +17,10 @@ const store = createStore(
   applyMiddleware(...middleware)
 )
 
-render(
+const container = document.getElementById('root');
+const root = createRoot(container);
+root.render(
   <Provider store={store}>
     <App />
-  </Provider>,
-  document.getElementById('root')
+  </Provider>
 )

--- a/examples/real-world/src/index.js
+++ b/examples/real-world/src/index.js
@@ -1,14 +1,15 @@
 import React from 'react'
-import { render } from 'react-dom'
+import { createRoot } from 'react-dom/client'
 import { BrowserRouter as Router } from 'react-router-dom'
 import Root from './containers/Root'
 import configureStore from './store/configureStore'
 
 const store = configureStore()
+const container = document.getElementById('root');
+const root = createRoot(container);
 
-render(
+root.render(
   <Router>
     <Root store={store} />
-  </Router>,
-  document.getElementById('root')
+  </Router>
 )

--- a/examples/shopping-cart/src/index.js
+++ b/examples/shopping-cart/src/index.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render } from 'react-dom'
+import { createRoot } from 'react-dom/client'
 import { createStore, applyMiddleware } from 'redux'
 import { Provider } from 'react-redux'
 import { createLogger } from 'redux-logger'
@@ -20,9 +20,10 @@ const store = createStore(
 
 store.dispatch(getAllProducts())
 
-render(
+const container = document.getElementById('root');
+const root = createRoot(container);
+root.render(
   <Provider store={store}>
     <App />
-  </Provider>,
-  document.getElementById('root')
+  </Provider>
 )

--- a/examples/todomvc/src/index.js
+++ b/examples/todomvc/src/index.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render } from 'react-dom'
+import { createRoot } from 'react-dom/client'
 import { createStore } from 'redux'
 import { Provider } from 'react-redux'
 import App from './components/App'
@@ -7,10 +7,11 @@ import reducer from './reducers'
 import 'todomvc-app-css/index.css'
 
 const store = createStore(reducer)
+const container = document.getElementById('root');
+const root = createRoot(container);
 
-render(
+root.render(
   <Provider store={store}>
     <App />
-  </Provider>,
-  document.getElementById('root')
+  </Provider>
 )

--- a/examples/todos-with-undo/src/index.js
+++ b/examples/todos-with-undo/src/index.js
@@ -1,15 +1,16 @@
 import React from 'react'
-import { render } from 'react-dom'
+import { createRoot } from 'react-dom/client'
 import { createStore } from 'redux'
 import { Provider } from 'react-redux'
 import App from './components/App'
 import reducer from './reducers'
 
 const store = createStore(reducer)
+const container = document.getElementById('root');
+const root = createRoot(container);
 
-render(
+root.render(
   <Provider store={store}>
     <App />
-  </Provider>,
-  document.getElementById('root')
+  </Provider>
 )

--- a/examples/todos/src/index.js
+++ b/examples/todos/src/index.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render } from 'react-dom'
+import { createRoot } from 'react-dom/client'
 import { createStore } from 'redux'
 import { Provider } from 'react-redux'
 import App from './components/App'
@@ -7,9 +7,10 @@ import rootReducer from './reducers'
 
 const store = createStore(rootReducer)
 
-render(
+const container = document.getElementById('root');
+const root = createRoot(container);
+root.render(
   <Provider store={store}>
     <App />
-  </Provider>,
-  document.getElementById('root')
+  </Provider>
 )

--- a/examples/tree-view/src/index.js
+++ b/examples/tree-view/src/index.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render } from 'react-dom'
+import { createRoot } from 'react-dom/client'
 import { createStore } from 'redux'
 import { Provider } from 'react-redux'
 import reducer from './reducers'
@@ -9,9 +9,10 @@ import Node from './containers/Node'
 const tree = generateTree()
 const store = createStore(reducer, tree)
 
-render(
+const container = document.getElementById('root');
+const root = createRoot(container);
+root.render(
   <Provider store={store}>
     <Node id={0} />
-  </Provider>,
-  document.getElementById('root')
+  </Provider>
 )

--- a/examples/universal/client/index.js
+++ b/examples/universal/client/index.js
@@ -1,17 +1,17 @@
 import 'babel-polyfill'
 import React from 'react'
-import { render } from 'react-dom'
+import { createRoot } from 'react-dom/client'
 import { Provider } from 'react-redux'
 import configureStore from '../common/store/configureStore'
 import App from '../common/containers/App'
 
 const store = configureStore(window.__PRELOADED_STATE__)
 delete window.__PRELOADED_STATE__
-const rootElement = document.getElementById('app')
+const container = document.getElementById('app')
+const root = createRoot(container)
 
-render(
+root.render(
   <Provider store={store}>
     <App/>
-  </Provider>,
-  rootElement
+  </Provider>
 )


### PR DESCRIPTION
# test
## Tasks
### Adopt new hooks
Adopt the useSyncExternalStore and useInsertionEffect hooks introduced in React 18

#### Instructions
- Replace any CSS-in-JS style injections in render with useInsertionEffect
    - docs/node_modules/react-redux/es/utils/useIsomorphicLayoutEffect.js
    - docs/node_modules/react-redux/lib/utils/useIsomorphicLayoutEffect.js
    - docs/node_modules/use-sync-external-store/cjs/use-sync-external-store-shim.native.development.js
    - docs/node_modules/use-sync-external-store/cjs/use-sync-external-store-shim.native.production.min.js
    - docs/node_modules/use-sync-external-store/cjs/use-sync-external-store-shim.production.min.js
    - docs/node_modules/use-sync-external-store/cjs/use-sync-external-store-shim/with-selector.development.js
    - docs/node_modules/use-sync-external-store/cjs/use-sync-external-store-with-selector.development.js
### Update Client Rendering APIs
React 18 introduces a new root API which provides better ergonomics for managing roots. The new root API also enables the new concurrent renderer, which allows you to opt-into concurrent features.

#### Instructions
- Replace render with createRoot
    - examples/async/src/index.js
    - examples/real-world/src/index.js
    - examples/shopping-cart/src/index.js
    - examples/todomvc/src/index.js
    - examples/todos-with-undo/src/index.js
    - examples/todos/src/index.js
    - examples/tree-view/src/index.js
    - examples/universal/client/index.js

## Errors

### Update Client Rendering APIs
React 18 introduces a new root API which provides better ergonomics for managing roots. The new root API also enables the new concurrent renderer, which allows you to opt-into concurrent features.

#### Instructions
- Replace render with createRoot
    - migrations/test/harfoots/redux/docs/node_modules/react-redux/dist/react-redux.js: migrations/test/harfoots/redux/docs/node_modules/react-redux/dist/react-redux.js for task: Update Client Rendering APIs, step: Replace render with createRoot exceeds 2000 tokens and not currently supported. 

### Adopt new hooks
Adopt the useSyncExternalStore and useInsertionEffect hooks introduced in React 18

#### Instructions
- Replace any CSS-in-JS style injections in render with useInsertionEffect
    - migrations/test/harfoots/redux/docs/node_modules/react-redux/dist/react-redux.js: migrations/test/harfoots/redux/docs/node_modules/react-redux/dist/react-redux.js for task: Adopt new hooks, step: Replace any CSS-in-JS style injections in render with useInsertionEffect exceeds 2000 tokens and not currently supported. 

### Update Client Rendering APIs
React 18 introduces a new root API which provides better ergonomics for managing roots. The new root API also enables the new concurrent renderer, which allows you to opt-into concurrent features.

#### Instructions
- Replace render with createRoot
    - migrations/test/harfoots/redux/docs/node_modules/@reduxjs/toolkit/src/query/tests/optimisticUpserts.test.tsx: migrations/test/harfoots/redux/docs/node_modules/@reduxjs/toolkit/src/query/tests/optimisticUpserts.test.tsx for task: Update Client Rendering APIs, step: Replace render with createRoot exceeds 2000 tokens and not currently supported. 

    - migrations/test/harfoots/redux/docs/node_modules/ora/index.js: migrations/test/harfoots/redux/docs/node_modules/ora/index.js for task: Update Client Rendering APIs, step: Replace render with createRoot exceeds 2000 tokens and not currently supported. 

    - migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/pure.js: migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/pure.js for task: Update Client Rendering APIs, step: Replace render with createRoot exceeds 2000 tokens and not currently supported. 

- Replace unmountComponentAtNode with root.unmount
    - migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/pure.js: migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/pure.js for task: Update Client Rendering APIs, step: Replace unmountComponentAtNode with root.unmount exceeds 2000 tokens and not currently supported. 

- Replace hydrate with hydrateRoot
    - migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/pure.js: migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/pure.js for task: Update Client Rendering APIs, step: Replace hydrate with hydrateRoot exceeds 2000 tokens and not currently supported. 

### Adopt new hooks
Adopt the useSyncExternalStore and useInsertionEffect hooks introduced in React 18

#### Instructions
- Replace any CSS-in-JS style injections in render with useInsertionEffect
    - migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/pure.js: migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/pure.js for task: Adopt new hooks, step: Replace any CSS-in-JS style injections in render with useInsertionEffect exceeds 2000 tokens and not currently supported. 

### Update Client Rendering APIs
React 18 introduces a new root API which provides better ergonomics for managing roots. The new root API also enables the new concurrent renderer, which allows you to opt-into concurrent features.

#### Instructions
- Replace render with createRoot
    - migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.pure.esm.js: migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.pure.esm.js for task: Update Client Rendering APIs, step: Replace render with createRoot exceeds 2000 tokens and not currently supported. 

- Replace unmountComponentAtNode with root.unmount
    - migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.pure.esm.js: migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.pure.esm.js for task: Update Client Rendering APIs, step: Replace unmountComponentAtNode with root.unmount exceeds 2000 tokens and not currently supported. 

- Replace hydrate with hydrateRoot
    - migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.pure.esm.js: migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.pure.esm.js for task: Update Client Rendering APIs, step: Replace hydrate with hydrateRoot exceeds 2000 tokens and not currently supported. 

### Adopt new hooks
Adopt the useSyncExternalStore and useInsertionEffect hooks introduced in React 18

#### Instructions
- Replace any CSS-in-JS style injections in render with useInsertionEffect
    - migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.pure.esm.js: migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.pure.esm.js for task: Adopt new hooks, step: Replace any CSS-in-JS style injections in render with useInsertionEffect exceeds 2000 tokens and not currently supported. 

### Handle Deprecations
Several ReactDOM methods have been deprecated in React 18

#### Instructions
- Replace ReactDOM.render with ReactDOM.createRoot
    - migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.pure.esm.js: migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.pure.esm.js for task: Handle Deprecations, step: Replace ReactDOM.render with ReactDOM.createRoot exceeds 2000 tokens and not currently supported. 

- Replace ReactDOM.hydrate with ReactDOM.createRoot
    - migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.pure.esm.js: migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.pure.esm.js for task: Handle Deprecations, step: Replace ReactDOM.hydrate with ReactDOM.createRoot exceeds 2000 tokens and not currently supported. 

### Update Client Rendering APIs
React 18 introduces a new root API which provides better ergonomics for managing roots. The new root API also enables the new concurrent renderer, which allows you to opt-into concurrent features.

#### Instructions
- Replace render with createRoot
    - migrations/test/harfoots/redux/docs/node_modules/react-redux/es/components/connect.js: migrations/test/harfoots/redux/docs/node_modules/react-redux/es/components/connect.js for task: Update Client Rendering APIs, step: Replace render with createRoot exceeds 2000 tokens and not currently supported. 

### Adopt new hooks
Adopt the useSyncExternalStore and useInsertionEffect hooks introduced in React 18

#### Instructions
- Replace any CSS-in-JS style injections in render with useInsertionEffect
    - migrations/test/harfoots/redux/docs/node_modules/react-redux/es/components/connect.js: migrations/test/harfoots/redux/docs/node_modules/react-redux/es/components/connect.js for task: Adopt new hooks, step: Replace any CSS-in-JS style injections in render with useInsertionEffect exceeds 2000 tokens and not currently supported. 

### Update Client Rendering APIs
React 18 introduces a new root API which provides better ergonomics for managing roots. The new root API also enables the new concurrent renderer, which allows you to opt-into concurrent features.

#### Instructions
- Replace render with createRoot
    - migrations/test/harfoots/redux/docs/node_modules/@reduxjs/toolkit/src/query/tests/buildHooks.test.tsx: migrations/test/harfoots/redux/docs/node_modules/@reduxjs/toolkit/src/query/tests/buildHooks.test.tsx for task: Update Client Rendering APIs, step: Replace render with createRoot exceeds 2000 tokens and not currently supported. 

    - migrations/test/harfoots/redux/docs/node_modules/@reduxjs/toolkit/src/query/tests/refetchingBehaviors.test.tsx: migrations/test/harfoots/redux/docs/node_modules/@reduxjs/toolkit/src/query/tests/refetchingBehaviors.test.tsx for task: Update Client Rendering APIs, step: Replace render with createRoot exceeds 2000 tokens and not currently supported. 

    - migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.pure.umd.js: migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.pure.umd.js for task: Update Client Rendering APIs, step: Replace render with createRoot exceeds 2000 tokens and not currently supported. 

- Replace unmountComponentAtNode with root.unmount
    - migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.pure.umd.js: migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.pure.umd.js for task: Update Client Rendering APIs, step: Replace unmountComponentAtNode with root.unmount exceeds 2000 tokens and not currently supported. 

- Replace hydrate with hydrateRoot
    - migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.pure.umd.js: migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.pure.umd.js for task: Update Client Rendering APIs, step: Replace hydrate with hydrateRoot exceeds 2000 tokens and not currently supported. 

### Adopt new hooks
Adopt the useSyncExternalStore and useInsertionEffect hooks introduced in React 18

#### Instructions
- Replace any CSS-in-JS style injections in render with useInsertionEffect
    - migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.pure.umd.js: migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.pure.umd.js for task: Adopt new hooks, step: Replace any CSS-in-JS style injections in render with useInsertionEffect exceeds 2000 tokens and not currently supported. 

### Update Client Rendering APIs
React 18 introduces a new root API which provides better ergonomics for managing roots. The new root API also enables the new concurrent renderer, which allows you to opt-into concurrent features.

#### Instructions
- Replace render with createRoot
    - migrations/test/harfoots/redux/docs/node_modules/react-redux/lib/components/connect.js: migrations/test/harfoots/redux/docs/node_modules/react-redux/lib/components/connect.js for task: Update Client Rendering APIs, step: Replace render with createRoot exceeds 2000 tokens and not currently supported. 

### Adopt new hooks
Adopt the useSyncExternalStore and useInsertionEffect hooks introduced in React 18

#### Instructions
- Replace any CSS-in-JS style injections in render with useInsertionEffect
    - migrations/test/harfoots/redux/docs/node_modules/react-redux/lib/components/connect.js: migrations/test/harfoots/redux/docs/node_modules/react-redux/lib/components/connect.js for task: Adopt new hooks, step: Replace any CSS-in-JS style injections in render with useInsertionEffect exceeds 2000 tokens and not currently supported. 

### Update Client Rendering APIs
React 18 introduces a new root API which provides better ergonomics for managing roots. The new root API also enables the new concurrent renderer, which allows you to opt-into concurrent features.

#### Instructions
- Replace render with createRoot
    - migrations/test/harfoots/redux/docs/node_modules/@reduxjs/toolkit/dist/query/react/rtk-query-react.umd.min.js: migrations/test/harfoots/redux/docs/node_modules/@reduxjs/toolkit/dist/query/react/rtk-query-react.umd.min.js for task: Update Client Rendering APIs, step: Replace render with createRoot exceeds 2000 tokens and not currently supported. 

### Adopt new hooks
Adopt the useSyncExternalStore and useInsertionEffect hooks introduced in React 18

#### Instructions
- Replace any CSS-in-JS style injections in render with useInsertionEffect
    - migrations/test/harfoots/redux/docs/node_modules/@reduxjs/toolkit/dist/query/react/rtk-query-react.umd.min.js: migrations/test/harfoots/redux/docs/node_modules/@reduxjs/toolkit/dist/query/react/rtk-query-react.umd.min.js for task: Adopt new hooks, step: Replace any CSS-in-JS style injections in render with useInsertionEffect exceeds 2000 tokens and not currently supported. 

### Update Client Rendering APIs
React 18 introduces a new root API which provides better ergonomics for managing roots. The new root API also enables the new concurrent renderer, which allows you to opt-into concurrent features.

#### Instructions
- Replace render with createRoot
    - migrations/test/harfoots/redux/docs/node_modules/react-redux/src/components/connect.tsx: migrations/test/harfoots/redux/docs/node_modules/react-redux/src/components/connect.tsx for task: Update Client Rendering APIs, step: Replace render with createRoot exceeds 2000 tokens and not currently supported. 

    - migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.esm.js: migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.esm.js for task: Update Client Rendering APIs, step: Replace render with createRoot exceeds 2000 tokens and not currently supported. 

- Replace unmountComponentAtNode with root.unmount
    - migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.esm.js: migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.esm.js for task: Update Client Rendering APIs, step: Replace unmountComponentAtNode with root.unmount exceeds 2000 tokens and not currently supported. 

- Replace hydrate with hydrateRoot
    - migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.esm.js: migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.esm.js for task: Update Client Rendering APIs, step: Replace hydrate with hydrateRoot exceeds 2000 tokens and not currently supported. 

### Adopt new hooks
Adopt the useSyncExternalStore and useInsertionEffect hooks introduced in React 18

#### Instructions
- Replace any CSS-in-JS style injections in render with useInsertionEffect
    - migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.esm.js: migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.esm.js for task: Adopt new hooks, step: Replace any CSS-in-JS style injections in render with useInsertionEffect exceeds 2000 tokens and not currently supported. 

### Handle Deprecations
Several ReactDOM methods have been deprecated in React 18

#### Instructions
- Replace ReactDOM.render with ReactDOM.createRoot
    - migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.esm.js: migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.esm.js for task: Handle Deprecations, step: Replace ReactDOM.render with ReactDOM.createRoot exceeds 2000 tokens and not currently supported. 

- Replace ReactDOM.hydrate with ReactDOM.createRoot
    - migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.esm.js: migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.esm.js for task: Handle Deprecations, step: Replace ReactDOM.hydrate with ReactDOM.createRoot exceeds 2000 tokens and not currently supported. 

### Update Client Rendering APIs
React 18 introduces a new root API which provides better ergonomics for managing roots. The new root API also enables the new concurrent renderer, which allows you to opt-into concurrent features.

#### Instructions
- Replace render with createRoot
    - migrations/test/harfoots/redux/docs/node_modules/@types/react-dom/test-utils/index.d.ts: migrations/test/harfoots/redux/docs/node_modules/@types/react-dom/test-utils/index.d.ts for task: Update Client Rendering APIs, step: Replace render with createRoot exceeds 2000 tokens and not currently supported. 

    - migrations/test/harfoots/redux/docs/node_modules/@reduxjs/toolkit/src/query/tests/useMutation-fixedCacheKey.test.tsx: migrations/test/harfoots/redux/docs/node_modules/@reduxjs/toolkit/src/query/tests/useMutation-fixedCacheKey.test.tsx for task: Update Client Rendering APIs, step: Replace render with createRoot exceeds 2000 tokens and not currently supported. 

    - migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.pure.cjs.js: migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.pure.cjs.js for task: Update Client Rendering APIs, step: Replace render with createRoot exceeds 2000 tokens and not currently supported. 

- Replace unmountComponentAtNode with root.unmount
    - migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.pure.cjs.js: migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.pure.cjs.js for task: Update Client Rendering APIs, step: Replace unmountComponentAtNode with root.unmount exceeds 2000 tokens and not currently supported. 

- Replace hydrate with hydrateRoot
    - migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.pure.cjs.js: migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.pure.cjs.js for task: Update Client Rendering APIs, step: Replace hydrate with hydrateRoot exceeds 2000 tokens and not currently supported. 

### Adopt new hooks
Adopt the useSyncExternalStore and useInsertionEffect hooks introduced in React 18

#### Instructions
- Replace any CSS-in-JS style injections in render with useInsertionEffect
    - migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.pure.cjs.js: migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.pure.cjs.js for task: Adopt new hooks, step: Replace any CSS-in-JS style injections in render with useInsertionEffect exceeds 2000 tokens and not currently supported. 

### Update Client Rendering APIs
React 18 introduces a new root API which provides better ergonomics for managing roots. The new root API also enables the new concurrent renderer, which allows you to opt-into concurrent features.

#### Instructions
- Replace render with createRoot
    - migrations/test/harfoots/redux/docs/node_modules/@reduxjs/toolkit/dist/query/react/rtk-query-react.umd.js: migrations/test/harfoots/redux/docs/node_modules/@reduxjs/toolkit/dist/query/react/rtk-query-react.umd.js for task: Update Client Rendering APIs, step: Replace render with createRoot exceeds 2000 tokens and not currently supported. 

- Replace unmountComponentAtNode with root.unmount
    - migrations/test/harfoots/redux/docs/node_modules/@reduxjs/toolkit/dist/query/react/rtk-query-react.umd.js: migrations/test/harfoots/redux/docs/node_modules/@reduxjs/toolkit/dist/query/react/rtk-query-react.umd.js for task: Update Client Rendering APIs, step: Replace unmountComponentAtNode with root.unmount exceeds 2000 tokens and not currently supported. 

- Replace hydrate with hydrateRoot
    - migrations/test/harfoots/redux/docs/node_modules/@reduxjs/toolkit/dist/query/react/rtk-query-react.umd.js: migrations/test/harfoots/redux/docs/node_modules/@reduxjs/toolkit/dist/query/react/rtk-query-react.umd.js for task: Update Client Rendering APIs, step: Replace hydrate with hydrateRoot exceeds 2000 tokens and not currently supported. 

### Adopt new hooks
Adopt the useSyncExternalStore and useInsertionEffect hooks introduced in React 18

#### Instructions
- Replace any CSS-in-JS style injections in render with useInsertionEffect
    - migrations/test/harfoots/redux/docs/node_modules/@reduxjs/toolkit/dist/query/react/rtk-query-react.umd.js: migrations/test/harfoots/redux/docs/node_modules/@reduxjs/toolkit/dist/query/react/rtk-query-react.umd.js for task: Adopt new hooks, step: Replace any CSS-in-JS style injections in render with useInsertionEffect exceeds 2000 tokens and not currently supported. 

### Handle Deprecations
Several ReactDOM methods have been deprecated in React 18

#### Instructions
- Replace ReactDOM.render with ReactDOM.createRoot
    - migrations/test/harfoots/redux/docs/node_modules/@reduxjs/toolkit/dist/query/react/rtk-query-react.umd.js: migrations/test/harfoots/redux/docs/node_modules/@reduxjs/toolkit/dist/query/react/rtk-query-react.umd.js for task: Handle Deprecations, step: Replace ReactDOM.render with ReactDOM.createRoot exceeds 2000 tokens and not currently supported. 

- Replace ReactDOM.hydrate with ReactDOM.createRoot
    - migrations/test/harfoots/redux/docs/node_modules/@reduxjs/toolkit/dist/query/react/rtk-query-react.umd.js: migrations/test/harfoots/redux/docs/node_modules/@reduxjs/toolkit/dist/query/react/rtk-query-react.umd.js for task: Handle Deprecations, step: Replace ReactDOM.hydrate with ReactDOM.createRoot exceeds 2000 tokens and not currently supported. 

### Update Client Rendering APIs
React 18 introduces a new root API which provides better ergonomics for managing roots. The new root API also enables the new concurrent renderer, which allows you to opt-into concurrent features.

#### Instructions
- Replace render with createRoot
    - migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.pure.umd.min.js: migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.pure.umd.min.js for task: Update Client Rendering APIs, step: Replace render with createRoot exceeds 2000 tokens and not currently supported. 

- Replace unmountComponentAtNode with root.unmount
    - migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.pure.umd.min.js: migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.pure.umd.min.js for task: Update Client Rendering APIs, step: Replace unmountComponentAtNode with root.unmount exceeds 2000 tokens and not currently supported. 

- Replace hydrate with hydrateRoot
    - migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.pure.umd.min.js: migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.pure.umd.min.js for task: Update Client Rendering APIs, step: Replace hydrate with hydrateRoot exceeds 2000 tokens and not currently supported. 

### Adopt new hooks
Adopt the useSyncExternalStore and useInsertionEffect hooks introduced in React 18

#### Instructions
- Replace any CSS-in-JS style injections in render with useInsertionEffect
    - migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.pure.umd.min.js: migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.pure.umd.min.js for task: Adopt new hooks, step: Replace any CSS-in-JS style injections in render with useInsertionEffect exceeds 2000 tokens and not currently supported. 

### Update Client Rendering APIs
React 18 introduces a new root API which provides better ergonomics for managing roots. The new root API also enables the new concurrent renderer, which allows you to opt-into concurrent features.

#### Instructions
- Replace render with createRoot
    - migrations/test/harfoots/redux/docs/node_modules/@types/react/index.d.ts: migrations/test/harfoots/redux/docs/node_modules/@types/react/index.d.ts for task: Update Client Rendering APIs, step: Replace render with createRoot exceeds 2000 tokens and not currently supported. 

    - migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.umd.js: migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.umd.js for task: Update Client Rendering APIs, step: Replace render with createRoot exceeds 2000 tokens and not currently supported. 

- Replace unmountComponentAtNode with root.unmount
    - migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.umd.js: migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.umd.js for task: Update Client Rendering APIs, step: Replace unmountComponentAtNode with root.unmount exceeds 2000 tokens and not currently supported. 

- Replace hydrate with hydrateRoot
    - migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.umd.js: migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.umd.js for task: Update Client Rendering APIs, step: Replace hydrate with hydrateRoot exceeds 2000 tokens and not currently supported. 

### Adopt new hooks
Adopt the useSyncExternalStore and useInsertionEffect hooks introduced in React 18

#### Instructions
- Replace any CSS-in-JS style injections in render with useInsertionEffect
    - migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.umd.js: migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.umd.js for task: Adopt new hooks, step: Replace any CSS-in-JS style injections in render with useInsertionEffect exceeds 2000 tokens and not currently supported. 

### Update Client Rendering APIs
React 18 introduces a new root API which provides better ergonomics for managing roots. The new root API also enables the new concurrent renderer, which allows you to opt-into concurrent features.

#### Instructions
- Replace render with createRoot
    - migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.umd.min.js: migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.umd.min.js for task: Update Client Rendering APIs, step: Replace render with createRoot exceeds 2000 tokens and not currently supported. 

- Replace unmountComponentAtNode with root.unmount
    - migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.umd.min.js: migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.umd.min.js for task: Update Client Rendering APIs, step: Replace unmountComponentAtNode with root.unmount exceeds 2000 tokens and not currently supported. 

- Replace hydrate with hydrateRoot
    - migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.umd.min.js: migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.umd.min.js for task: Update Client Rendering APIs, step: Replace hydrate with hydrateRoot exceeds 2000 tokens and not currently supported. 

### Adopt new hooks
Adopt the useSyncExternalStore and useInsertionEffect hooks introduced in React 18

#### Instructions
- Replace any CSS-in-JS style injections in render with useInsertionEffect
    - migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.umd.min.js: migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.umd.min.js for task: Adopt new hooks, step: Replace any CSS-in-JS style injections in render with useInsertionEffect exceeds 2000 tokens and not currently supported. 

### Update Client Rendering APIs
React 18 introduces a new root API which provides better ergonomics for managing roots. The new root API also enables the new concurrent renderer, which allows you to opt-into concurrent features.

#### Instructions
- Replace render with createRoot
    - migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.cjs.js: migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.cjs.js for task: Update Client Rendering APIs, step: Replace render with createRoot exceeds 2000 tokens and not currently supported. 

- Replace unmountComponentAtNode with root.unmount
    - migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.cjs.js: migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.cjs.js for task: Update Client Rendering APIs, step: Replace unmountComponentAtNode with root.unmount exceeds 2000 tokens and not currently supported. 

- Replace hydrate with hydrateRoot
    - migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.cjs.js: migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.cjs.js for task: Update Client Rendering APIs, step: Replace hydrate with hydrateRoot exceeds 2000 tokens and not currently supported. 

### Adopt new hooks
Adopt the useSyncExternalStore and useInsertionEffect hooks introduced in React 18

#### Instructions
- Replace any CSS-in-JS style injections in render with useInsertionEffect
    - migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.cjs.js: migrations/test/harfoots/redux/docs/node_modules/@testing-library/react/dist/@testing-library/react.cjs.js for task: Adopt new hooks, step: Replace any CSS-in-JS style injections in render with useInsertionEffect exceeds 2000 tokens and not currently supported. 

### Update Client Rendering APIs
React 18 introduces a new root API which provides better ergonomics for managing roots. The new root API also enables the new concurrent renderer, which allows you to opt-into concurrent features.

#### Instructions
- Replace render with createRoot
    - migrations/test/harfoots/redux/docs/node_modules/@reduxjs/toolkit/src/query/tests/errorHandling.test.tsx: migrations/test/harfoots/redux/docs/node_modules/@reduxjs/toolkit/src/query/tests/errorHandling.test.tsx for task: Update Client Rendering APIs, step: Replace render with createRoot exceeds 2000 tokens and not currently supported. 

- Replace hydrate with hydrateRoot
    - migrations/test/harfoots/redux/docs/node_modules/msw/lib/node/index.js: migrations/test/harfoots/redux/docs/node_modules/msw/lib/node/index.js for task: Update Client Rendering APIs, step: Replace hydrate with hydrateRoot exceeds 2000 tokens and not currently supported. 

    - migrations/test/harfoots/redux/docs/node_modules/msw/lib/native/index.js: migrations/test/harfoots/redux/docs/node_modules/msw/lib/native/index.js for task: Update Client Rendering APIs, step: Replace hydrate with hydrateRoot exceeds 2000 tokens and not currently supported. 

    - migrations/test/harfoots/redux/docs/node_modules/msw/lib/iife/index.js: migrations/test/harfoots/redux/docs/node_modules/msw/lib/iife/index.js for task: Update Client Rendering APIs, step: Replace hydrate with hydrateRoot exceeds 2000 tokens and not currently supported. 

    - migrations/test/harfoots/redux/docs/node_modules/msw/lib/index.js: migrations/test/harfoots/redux/docs/node_modules/msw/lib/index.js for task: Update Client Rendering APIs, step: Replace hydrate with hydrateRoot exceeds 2000 tokens and not currently supported. 

### Adopt new hooks
Adopt the useSyncExternalStore and useInsertionEffect hooks introduced in React 18

#### Instructions
- Replace any CSS-in-JS style injections in render with useInsertionEffect
    - migrations/test/harfoots/redux/docs/node_modules/react-redux/dist/react-redux.min.js: migrations/test/harfoots/redux/docs/node_modules/react-redux/dist/react-redux.min.js for task: Adopt new hooks, step: Replace any CSS-in-JS style injections in render with useInsertionEffect exceeds 2000 tokens and not currently supported. 

    - migrations/test/harfoots/redux/docs/node_modules/react/umd/react.profiling.min.js: migrations/test/harfoots/redux/docs/node_modules/react/umd/react.profiling.min.js for task: Adopt new hooks, step: Replace any CSS-in-JS style injections in render with useInsertionEffect exceeds 2000 tokens and not currently supported. 

    - migrations/test/harfoots/redux/docs/node_modules/react/cjs/react.production.min.js: migrations/test/harfoots/redux/docs/node_modules/react/cjs/react.production.min.js for task: Adopt new hooks, step: Replace any CSS-in-JS style injections in render with useInsertionEffect exceeds 2000 tokens and not currently supported. 

    - migrations/test/harfoots/redux/docs/node_modules/@reduxjs/toolkit/dist/query/react/rtk-query-react.modern.development.js: migrations/test/harfoots/redux/docs/node_modules/@reduxjs/toolkit/dist/query/react/rtk-query-react.modern.development.js for task: Adopt new hooks, step: Replace any CSS-in-JS style injections in render with useInsertionEffect exceeds 2000 tokens and not currently supported. 

    - migrations/test/harfoots/redux/docs/node_modules/react/umd/react.production.min.js: migrations/test/harfoots/redux/docs/node_modules/react/umd/react.production.min.js for task: Adopt new hooks, step: Replace any CSS-in-JS style injections in render with useInsertionEffect exceeds 2000 tokens and not currently supported. 

    - migrations/test/harfoots/redux/docs/node_modules/use-sync-external-store/cjs/use-sync-external-store-shim.development.js: migrations/test/harfoots/redux/docs/node_modules/use-sync-external-store/cjs/use-sync-external-store-shim.development.js for task: Adopt new hooks, step: Replace any CSS-in-JS style injections in render with useInsertionEffect exceeds 2000 tokens and not currently supported. 

    - migrations/test/harfoots/redux/docs/node_modules/react/cjs/react.development.js: migrations/test/harfoots/redux/docs/node_modules/react/cjs/react.development.js for task: Adopt new hooks, step: Replace any CSS-in-JS style injections in render with useInsertionEffect exceeds 2000 tokens and not currently supported. 

    - migrations/test/harfoots/redux/docs/node_modules/@reduxjs/toolkit/dist/query/react/rtk-query-react.modern.js: migrations/test/harfoots/redux/docs/node_modules/@reduxjs/toolkit/dist/query/react/rtk-query-react.modern.js for task: Adopt new hooks, step: Replace any CSS-in-JS style injections in render with useInsertionEffect exceeds 2000 tokens and not currently supported. 

    - migrations/test/harfoots/redux/docs/node_modules/react/umd/react.development.js: migrations/test/harfoots/redux/docs/node_modules/react/umd/react.development.js for task: Adopt new hooks, step: Replace any CSS-in-JS style injections in render with useInsertionEffect exceeds 2000 tokens and not currently supported. 

    - migrations/test/harfoots/redux/docs/node_modules/@reduxjs/toolkit/dist/query/react/rtk-query-react.cjs.production.min.js: migrations/test/harfoots/redux/docs/node_modules/@reduxjs/toolkit/dist/query/react/rtk-query-react.cjs.production.min.js for task: Adopt new hooks, step: Replace any CSS-in-JS style injections in render with useInsertionEffect exceeds 2000 tokens and not currently supported. 

    - migrations/test/harfoots/redux/docs/node_modules/@reduxjs/toolkit/dist/query/react/rtk-query-react.esm.js: migrations/test/harfoots/redux/docs/node_modules/@reduxjs/toolkit/dist/query/react/rtk-query-react.esm.js for task: Adopt new hooks, step: Replace any CSS-in-JS style injections in render with useInsertionEffect exceeds 2000 tokens and not currently supported. 

    - migrations/test/harfoots/redux/docs/node_modules/@reduxjs/toolkit/dist/query/react/rtk-query-react.modern.production.min.js: migrations/test/harfoots/redux/docs/node_modules/@reduxjs/toolkit/dist/query/react/rtk-query-react.modern.production.min.js for task: Adopt new hooks, step: Replace any CSS-in-JS style injections in render with useInsertionEffect exceeds 2000 tokens and not currently supported. 

    - migrations/test/harfoots/redux/docs/node_modules/@reduxjs/toolkit/dist/query/react/rtk-query-react.cjs.development.js: migrations/test/harfoots/redux/docs/node_modules/@reduxjs/toolkit/dist/query/react/rtk-query-react.cjs.development.js for task: Adopt new hooks, step: Replace any CSS-in-JS style injections in render with useInsertionEffect exceeds 2000 tokens and not currently supported. 
